### PR TITLE
Backport 45da3aea22fd85f214e661b2c98631cb91ddb55d

### DIFF
--- a/make/modules/java.base/Gendata.gmk
+++ b/make/modules/java.base/Gendata.gmk
@@ -60,7 +60,11 @@ TARGETS += $(GENDATA_CURDATA)
 
 ################################################################################
 
-GENDATA_CACERTS_SRC := $(TOPDIR)/make/data/cacerts/
+ifneq ($(CACERTS_SRC), )
+  GENDATA_CACERTS_SRC := $(CACERTS_SRC)
+else
+  GENDATA_CACERTS_SRC := $(TOPDIR)/make/data/cacerts/
+endif
 GENDATA_CACERTS := $(SUPPORT_OUTPUTDIR)/modules_libs/java.base/security/cacerts
 
 $(GENDATA_CACERTS): $(BUILD_TOOLS_JDK) $(wildcard $(GENDATA_CACERTS_SRC)/*)


### PR DESCRIPTION
This is the dependent fix to the --with-cacerts-src PR(https://github.com/openjdk/jdk17u-dev/pull/164), to resolve the incorrect variable resolution.